### PR TITLE
Fix BeautifulSoup parser warning

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,1 +1,2 @@
 v0.1.0, 2013-11-13 -- Initial release.
+v0.1.0, 2017-05-22 -- Fix BeautifulSoup parser warning.

--- a/noaaweather/weather.py
+++ b/noaaweather/weather.py
@@ -40,7 +40,7 @@ class noaa(object):
 
     def fetchByURL(self, strURL):
        page=urllib2.urlopen(strURL)
-       self.soup = BeautifulSoup(page.read())
+       self.soup = BeautifulSoup(page.read(), 'html.parser')
        self.buildTimeSeries()
        #self.buildTemps()
        self.buildElements('temperature', {'temperature'})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='noaaweather',
-    version='0.1.0',
+    version='0.1.1',
     author='Matthew Howland',
     author_email='matt.howland@lab45.com',
     packages=['noaaweather', 'noaaweather.test'],


### PR DESCRIPTION
Explicitly specify html.parser when calling BeautifulSoup

Fixes #1 
